### PR TITLE
revert 912dfd8a8... Deprecate SIP service support.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -587,6 +587,16 @@
             </intent-filter>
         </receiver>
 
+        <activity android:name="com.android.services.telephony.sip.SipPhoneAccountSettingsActivity"
+                android:theme="@android:style/Theme.NoDisplay"
+                android:exported="true"
+                android:excludeFromRecents="true">
+            <intent-filter>
+                <action android:name="android.telecom.action.CONFIGURE_PHONE_ACCOUNT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <activity android:label="Sip Settings"
                   android:name="com.android.services.telephony.sip.SipSettings"
                   android:theme="@style/DialerSettingsLight"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -644,13 +644,6 @@
     <string name="limited_sim_function_with_phone_num_notification_message"><xliff:g id="carrier_name">%1$s</xliff:g> calls and data services may be blocked while using <xliff:g id="phone_number">%2$s</xliff:g>.</string>
     <!-- Notification message for limited sim function during dual sim [CHAR LIMIT=80]-->
     <string name="limited_sim_function_notification_message"><xliff:g id="carrier_name">%1$s</xliff:g> calls and data services may be blocked while using another SIM.</string>
-    <!-- Notification title for SIP accounts removed -->
-    <string name="sip_accounts_removed_notification_title">Deprecated SIP accounts found and removed</string>
-    <!-- Notification message for SIP accoutns removed -->
-    <string name="sip_accounts_removed_notification_message">
-        SIP calling is no longer supported by Android platform.\nYour existing SIP accounts <xliff:g id="removed_sip_accounts">%s</xliff:g> have been removed.\nPlease confirm your default calling account setting.
-    </string>
-    <string name="sip_accounts_removed_notification_action">Go to settings</string>
     <!-- Mobile network settings screen, data usage setting check box name -->
     <string name="data_usage_title">App data usage</string>
     <!-- Summary about how much data has been used in a date range [CHAR LIMIT=100] -->
@@ -2193,7 +2186,4 @@
     <!-- name of the notification that pops up during
     a phone call when there is bad call quality -->
     <string name="call_quality_notification_name">Call Quality Notification</string>
-    <!-- Telephony notification channel name for a channel containing SIP accounts removed
-     notificatios -->
-    <string name="notification_channel_sip_account">Deprecated SIP accounts</string>
 </resources>

--- a/res/xml/phone_account_settings.xml
+++ b/res/xml/phone_account_settings.xml
@@ -55,4 +55,34 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:key="phone_accounts_sip_settings_category_key"
+        android:title="@string/sip_settings"
+        android:persistent="false">
+
+        <PreferenceScreen
+            android:title="@string/sip_accounts"
+            android:persistent="false">
+
+            <intent android:action="android.intent.action.MAIN"
+                android:targetPackage="com.android.phone"
+                android:targetClass="com.android.services.telephony.sip.SipSettings" />
+
+        </PreferenceScreen>
+
+        <ListPreference
+            android:key="use_sip_calling_options_key"
+            android:title="@string/sip_call_options_title"
+            android:persistent="true"
+            android:entries="@array/sip_call_options_entries"
+            android:entryValues="@array/sip_call_options_values"/>
+
+        <SwitchPreference
+            android:key="sip_receive_calls_key"
+            android:title="@string/sip_receive_calls"
+            android:summary="@string/sip_receive_calls_summary"
+            android:persistent="true"/>
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/sip/src/com/android/services/telephony/sip/SipAccountRegistry.java
+++ b/sip/src/com/android/services/telephony/sip/SipAccountRegistry.java
@@ -16,12 +16,8 @@
 
 package com.android.services.telephony.sip;
 
-import android.app.Notification;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.Context;
-import android.content.Intent;
+import android.net.sip.SipException;
 import android.net.sip.SipManager;
 import android.net.sip.SipProfile;
 import android.telecom.PhoneAccount;
@@ -29,13 +25,9 @@ import android.telecom.PhoneAccountHandle;
 import android.telecom.TelecomManager;
 import android.util.Log;
 
-import com.android.phone.R;
-
-import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
 
 /**
  * Manages the {@link PhoneAccount} entries for SIP calling.
@@ -50,6 +42,41 @@ public final class SipAccountRegistry {
 
         SipProfile getProfile() {
             return mProfile;
+        }
+
+        /**
+         * Starts the SIP service associated with the SIP profile.
+         *
+         * @param sipManager The SIP manager.
+         * @param context The context.
+         * @param isReceivingCalls {@code True} if the sip service is being started to make and
+         *          receive calls.  {@code False} if the sip service is being started only for
+         *          outgoing calls.
+         * @return {@code True} if the service started successfully.
+         */
+        boolean startSipService(SipManager sipManager, Context context, boolean isReceivingCalls) {
+            if (VERBOSE) log("startSipService, profile: " + mProfile);
+            try {
+                // Stop the Sip service for the profile if it is already running.  This is important
+                // if we are changing the state of the "receive calls" option.
+                sipManager.close(mProfile.getUriString());
+
+                // Start the sip service for the profile.
+                if (isReceivingCalls) {
+                    sipManager.open(
+                            mProfile,
+                            SipUtil.createIncomingCallPendingIntent(context,
+                                    mProfile.getProfileName()),
+                            null);
+                } else {
+                    sipManager.open(mProfile);
+                }
+                return true;
+            } catch (SipException e) {
+                log("startSipService, profile: " + mProfile.getProfileName() +
+                        ", exception: " + e);
+            }
+            return false;
         }
 
         /**
@@ -75,15 +102,8 @@ public final class SipAccountRegistry {
     private static final String PREFIX = "[SipAccountRegistry] ";
     private static final boolean VERBOSE = false; /* STOP SHIP if true */
     private static final SipAccountRegistry INSTANCE = new SipAccountRegistry();
-    private static final String NOTIFICATION_TAG = SipAccountRegistry.class.getSimpleName();
-    private static final int SIP_ACCOUNTS_REMOVED_NOTIFICATION_ID = 1;
-
-    private static final String CHANNEL_ID_SIP_ACCOUNTS_REMOVED = "sipAccountsRemoved";
 
     private final List<AccountEntry> mAccounts = new CopyOnWriteArrayList<>();
-
-    private NotificationChannel mNotificationChannel;
-    private NotificationManager mNm;
 
     private SipAccountRegistry() {}
 
@@ -95,20 +115,8 @@ public final class SipAccountRegistry {
      * Sets up the Account registry and performs any upgrade operations before it is used.
      */
     public void setup(Context context) {
-        setupNotificationChannel(context);
         verifyAndPurgeInvalidPhoneAccounts(context);
-        startSipProfilesAsync(context);
-    }
-
-    private void setupNotificationChannel(Context context) {
-        mNotificationChannel = new NotificationChannel(
-                CHANNEL_ID_SIP_ACCOUNTS_REMOVED,
-                context.getText(R.string.notification_channel_sip_account),
-                NotificationManager.IMPORTANCE_HIGH);
-        mNm = context.getSystemService(NotificationManager.class);
-        if (mNm != null) {
-            mNm.createNotificationChannel(mNotificationChannel);
-        }
+        startSipProfilesAsync(context, (String) null, false);
     }
 
     /**
@@ -141,8 +149,8 @@ public final class SipAccountRegistry {
      * @param sipProfileName The name of the {@link SipProfile} to start, or {@code null} for all.
      * @param enableProfile Sip account should be enabled
      */
-    void startSipService(Context context, String sipProfileName, boolean enabledProfile) {
-        startSipProfilesAsync(context);
+    void startSipService(Context context, String sipProfileName, boolean enableProfile) {
+        startSipProfilesAsync(context, sipProfileName, enableProfile);
     }
 
     /**
@@ -185,20 +193,33 @@ public final class SipAccountRegistry {
     }
 
     /**
+     * Causes the SIP service to be restarted for all {@link SipProfile}s.  For example, if the user
+     * toggles the "receive calls" option for SIP, this method handles restarting the SIP services
+     * in the new mode.
+     *
+     * @param context The context.
+     */
+    public void restartSipService(Context context) {
+        startSipProfiles(context, null, false);
+    }
+
+    /**
      * Performs an asynchronous call to
      * {@link SipAccountRegistry#startSipProfiles(android.content.Context, String)}, starting the
      * specified SIP profile and registering its {@link android.telecom.PhoneAccount}.
      *
      * @param context The context.
+     * @param sipProfileName Name of the SIP profile.
+     * @param enableProfile Sip account should be enabled.
      */
     private void startSipProfilesAsync(
-            final Context context) {
+            final Context context, final String sipProfileName, final boolean enableProfile) {
         if (VERBOSE) log("startSipProfiles, start auto registration");
 
         new Thread(new Runnable() {
             @Override
             public void run() {
-                startSipProfiles(context);
+                startSipProfiles(context, sipProfileName, enableProfile);
             }}
         ).start();
     }
@@ -209,55 +230,48 @@ public final class SipAccountRegistry {
      * register the associated SIP account.
      *
      * @param context The context.
+     * @param sipProfileName A specific SIP profile Name to start, or {@code null} to start all.
+     * @param enableProfile Sip account should be enabled.
      */
-    private void startSipProfiles(Context context) {
+    private void startSipProfiles(Context context, String sipProfileName, boolean enableProfile) {
+        final SipPreferences sipPreferences = new SipPreferences(context);
+        boolean isReceivingCalls = sipPreferences.isReceivingCallsEnabled();
+        TelecomManager telecomManager = context.getSystemService(TelecomManager.class);
+        SipManager sipManager = SipManager.newInstance(context);
         SipProfileDb profileDb = new SipProfileDb(context);
         List<SipProfile> sipProfileList = profileDb.retrieveSipProfileList();
 
-        // If there're SIP profiles existing in DB, display a notification and delete all these
-        // profiles.
-        if (!sipProfileList.isEmpty()) {
-            for (SipProfile profile : sipProfileList) {
-                stopSipService(context, profile.getProfileName());
-                removeSipProfile(profile.getProfileName());
-                try {
-                    profileDb.deleteProfile(profile);
-                } catch (IOException e) {
-                    // Ignore
+        for (SipProfile profile : sipProfileList) {
+            // Register a PhoneAccount for the profile and optionally enable the primary
+            // profile.
+            if (sipProfileName == null || sipProfileName.equals(profile.getProfileName())) {
+                PhoneAccount phoneAccount = SipUtil.createPhoneAccount(context, profile);
+                telecomManager.registerPhoneAccount(phoneAccount);
+                if (enableProfile) {
+                    telecomManager.enablePhoneAccount(phoneAccount.getAccountHandle(), true);
                 }
+                startSipServiceForProfile(profile, sipManager, context, isReceivingCalls);
             }
-            sendSipAccountsRemovedNotification(context, sipProfileList);
         }
     }
 
-    private void sendSipAccountsRemovedNotification(Context context, List<SipProfile> profiles) {
-        String sipAccounts = profiles.stream().map(p -> p.getProfileName())
-                .collect(Collectors.joining(","));
+    /**
+     * Starts the SIP service for a sip profile and saves a new {@code AccountEntry} in the
+     * registry.
+     *
+     * @param profile The {@link SipProfile} to start.
+     * @param sipManager The SIP manager.
+     * @param context The context.
+     * @param isReceivingCalls {@code True} if the profile should be started such that it can
+     *      receive incoming calls.
+     */
+    private void startSipServiceForProfile(SipProfile profile, SipManager sipManager,
+            Context context, boolean isReceivingCalls) {
+        removeSipProfile(profile.getUriString());
 
-        Intent intent = new Intent(TelecomManager.ACTION_CHANGE_PHONE_ACCOUNTS);
-        intent.setFlags(Intent.FLAG_RECEIVER_INCLUDE_BACKGROUND);
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent,
-                PendingIntent.FLAG_IMMUTABLE);
-
-        Notification.Action action = new Notification.Action.Builder(R.drawable.ic_sim_card,
-                context.getString(R.string.sip_accounts_removed_notification_action),
-                pendingIntent).build();
-        Notification.Builder builder = new Notification.Builder(context)
-                .setSmallIcon(R.drawable.ic_sim_card)
-                .setChannelId(CHANNEL_ID_SIP_ACCOUNTS_REMOVED)
-                .setContentTitle(context.getText(R.string.sip_accounts_removed_notification_title))
-                .setStyle(new Notification.BigTextStyle()
-                .bigText(context.getString(
-                        R.string.sip_accounts_removed_notification_message,
-                        sipAccounts)))
-                .setAutoCancel(true)
-                .addAction(action);
-        Notification notification = builder.build();
-        if (mNm != null) {
-            mNm.notify(NOTIFICATION_TAG, SIP_ACCOUNTS_REMOVED_NOTIFICATION_ID,
-                    notification);
-        } else {
-            log("NotificationManager is null when send the notification of removed SIP accounts");
+        AccountEntry entry = new AccountEntry(profile);
+        if (entry.startSipService(sipManager, context, isReceivingCalls)) {
+            mAccounts.add(entry);
         }
     }
 

--- a/sip/src/com/android/services/telephony/sip/SipPhoneAccountSettingsActivity.java
+++ b/sip/src/com/android/services/telephony/sip/SipPhoneAccountSettingsActivity.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.services.telephony.sip;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.sip.SipProfile;
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.telecom.PhoneAccountHandle;
+import android.telecom.TelecomManager;
+import android.util.Log;
+
+/**
+ * This activity receives the standard telecom intent to open settings for a PhoneAccount. It
+ * translates the incoming phone account to a SIP profile and opens the corresponding
+ * PreferenceActivity for said profile.
+ */
+public final class SipPhoneAccountSettingsActivity extends Activity {
+    private static final String TAG = "SipSettingsActivity";
+
+    /** ${inheritDoc} */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+        Log.i(TAG, "" + intent);
+        if (intent != null) {
+            PhoneAccountHandle accountHandle = (PhoneAccountHandle)
+                    intent.getParcelableExtra(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE);
+            Log.i(TAG, "" + accountHandle);
+
+            if (accountHandle != null) {
+                SipProfileDb profileDb = new SipProfileDb(this);
+                String profileName = SipUtil.getSipProfileNameFromPhoneAccount(accountHandle);
+                SipProfile profile = profileDb.retrieveSipProfileFromName(profileName);
+                if (profile != null) {
+                    Intent settingsIntent = new Intent(this, SipEditor.class);
+                    settingsIntent.putExtra(SipSettings.KEY_SIP_PROFILE, (Parcelable) profile);
+                    startActivity(settingsIntent);
+                }
+            }
+        }
+
+        finish();
+    }
+}

--- a/src/com/android/phone/settings/PhoneAccountSettingsFragment.java
+++ b/src/com/android/phone/settings/PhoneAccountSettingsFragment.java
@@ -6,11 +6,14 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.drawable.Icon;
+import android.net.sip.SipManager;
 import android.os.Bundle;
 import android.os.UserManager;
+import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
+import android.preference.SwitchPreference;
 import android.telecom.PhoneAccount;
 import android.telecom.PhoneAccountHandle;
 import android.telecom.TelecomManager;
@@ -25,6 +28,9 @@ import com.android.internal.telephony.Phone;
 import com.android.phone.PhoneUtils;
 import com.android.phone.R;
 import com.android.phone.SubscriptionInfoHelper;
+import com.android.services.telephony.sip.SipAccountRegistry;
+import com.android.services.telephony.sip.SipPreferences;
+import com.android.services.telephony.sip.SipUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,6 +47,11 @@ public class PhoneAccountSettingsFragment extends PreferenceFragment
             "phone_accounts_accounts_list_category_key";
 
     private static final String ALL_CALLING_ACCOUNTS_KEY = "phone_accounts_all_calling_accounts";
+
+    private static final String SIP_SETTINGS_CATEGORY_PREF_KEY =
+            "phone_accounts_sip_settings_category_key";
+    private static final String USE_SIP_PREF_KEY = "use_sip_calling_options_key";
+    private static final String SIP_RECEIVE_CALLS_PREF_KEY = "sip_receive_calls_key";
 
     private static final String MAKE_AND_RECEIVE_CALLS_CATEGORY_KEY =
             "make_and_receive_calls_settings_category_key";
@@ -72,6 +83,10 @@ public class PhoneAccountSettingsFragment extends PreferenceFragment
 
     private PreferenceCategory mMakeAndReceiveCallsCategory;
     private boolean mMakeAndReceiveCallsCategoryPresent;
+
+    private ListPreference mUseSipCalling;
+    private SwitchPreference mSipReceiveCallsPreference;
+    private SipPreferences mSipPreferences;
 
     private final SubscriptionManager.OnSubscriptionsChangedListener
             mOnSubscriptionsChangeListener =
@@ -139,6 +154,39 @@ public class PhoneAccountSettingsFragment extends PreferenceFragment
         updateAccounts();
         updateMakeCallsOptions();
 
+        if (isPrimaryUser() && SipUtil.isVoipSupported(getActivity())) {
+            mSipPreferences = new SipPreferences(getActivity());
+
+            mUseSipCalling = (ListPreference)
+                    getPreferenceScreen().findPreference(USE_SIP_PREF_KEY);
+            mUseSipCalling.setEntries(!SipManager.isSipWifiOnly(getActivity())
+                    ? R.array.sip_call_options_wifi_only_entries
+                    : R.array.sip_call_options_entries);
+            mUseSipCalling.setOnPreferenceChangeListener(this);
+
+            int optionsValueIndex =
+                    mUseSipCalling.findIndexOfValue(mSipPreferences.getSipCallOption());
+            if (optionsValueIndex == -1) {
+                // If the option is invalid (eg. deprecated value), default to SIP_ADDRESS_ONLY.
+                mSipPreferences.setSipCallOption(
+                        getResources().getString(R.string.sip_address_only));
+                optionsValueIndex =
+                        mUseSipCalling.findIndexOfValue(mSipPreferences.getSipCallOption());
+            }
+            mUseSipCalling.setValueIndex(optionsValueIndex);
+            mUseSipCalling.setSummary(mUseSipCalling.getEntry());
+
+            mSipReceiveCallsPreference = (SwitchPreference)
+                    getPreferenceScreen().findPreference(SIP_RECEIVE_CALLS_PREF_KEY);
+            mSipReceiveCallsPreference.setEnabled(SipUtil.isPhoneIdle(getActivity()));
+            mSipReceiveCallsPreference.setChecked(
+                    mSipPreferences.isReceivingCallsEnabled());
+            mSipReceiveCallsPreference.setOnPreferenceChangeListener(this);
+        } else {
+            getPreferenceScreen().removePreference(
+                    getPreferenceScreen().findPreference(SIP_SETTINGS_CATEGORY_PREF_KEY));
+        }
+
         SubscriptionManager.from(getActivity()).addOnSubscriptionsChangedListener(
                 mOnSubscriptionsChangeListener);
     }
@@ -159,6 +207,21 @@ public class PhoneAccountSettingsFragment extends PreferenceFragment
      */
     @Override
     public boolean onPreferenceChange(Preference pref, Object objValue) {
+        if (pref == mUseSipCalling) {
+            String option = objValue.toString();
+            mSipPreferences.setSipCallOption(option);
+            mUseSipCalling.setValueIndex(mUseSipCalling.findIndexOfValue(option));
+            mUseSipCalling.setSummary(mUseSipCalling.getEntry());
+            return true;
+        } else if (pref == mSipReceiveCallsPreference) {
+            final boolean isEnabled = !mSipReceiveCallsPreference.isChecked();
+            new Thread(new Runnable() {
+                public void run() {
+                    handleSipReceiveCallsOption(isEnabled);
+                }
+            }).start();
+            return true;
+        }
         return false;
     }
 
@@ -192,6 +255,22 @@ public class PhoneAccountSettingsFragment extends PreferenceFragment
 
     @Override
     public void onAccountChanged(AccountSelectionPreference pref) {}
+
+    private synchronized void handleSipReceiveCallsOption(boolean isEnabled) {
+        Context context = getActivity();
+        if (context == null) {
+            // Return if the fragment is detached from parent activity before executed by thread.
+            return;
+        }
+
+        mSipPreferences.setReceivingCallsEnabled(isEnabled);
+
+        SipUtil.useSipToReceiveIncomingCalls(context, isEnabled);
+
+        // Restart all Sip services to ensure we reflect whether we are receiving calls.
+        SipAccountRegistry sipAccountRegistry = SipAccountRegistry.getInstance();
+        sipAccountRegistry.restartSipService(context);
+    }
 
     /**
      * Queries the telcomm manager to update the default outgoing account selection preference
@@ -330,24 +409,32 @@ public class PhoneAccountSettingsFragment extends PreferenceFragment
             mAccountList.removeAll();
             List<PhoneAccountHandle> allNonSimAccounts =
                     getCallingAccounts(false /* includeSims */, true /* includeDisabled */);
+            // Check to see if we should show the entire section at all.
+            if (shouldShowConnectionServiceList(allNonSimAccounts)) {
+                List<PhoneAccountHandle> enabledAccounts =
+                        getCallingAccounts(true /* includeSims */, false /* includeDisabled */);
+                // Initialize the account list with the set of enabled & SIM accounts.
+                initAccountList(enabledAccounts);
 
-            List<PhoneAccountHandle> enabledAccounts =
-                    getCallingAccounts(true /* includeSims */, false /* includeDisabled */);
-            // Initialize the account list with the set of enabled & SIM accounts.
-            initAccountList(enabledAccounts);
+                // Only show the 'Make Calls With..." option if there are multiple accounts.
+                if (enabledAccounts.size() > 1) {
+                    mMakeAndReceiveCallsCategory.addPreference(mDefaultOutgoingAccount);
+                    mMakeAndReceiveCallsCategoryPresent = true;
+                    mDefaultOutgoingAccount.setListener(this);
+                    updateDefaultOutgoingAccountsModel();
+                } else {
+                    mMakeAndReceiveCallsCategory.removePreference(mDefaultOutgoingAccount);
+                }
 
-            // Always show the 'Make Calls With..." option
-            mMakeAndReceiveCallsCategory.addPreference(mDefaultOutgoingAccount);
-            mMakeAndReceiveCallsCategoryPresent = true;
-            mDefaultOutgoingAccount.setListener(this);
-            updateDefaultOutgoingAccountsModel();
-
-            // If there are no third party (nonSim) accounts,
-            // then don't show enable/disable dialog.
-            if (!allNonSimAccounts.isEmpty()) {
-                mAccountList.addPreference(mAllCallingAccounts);
+                // If there are no third party (nonSim) accounts,
+                // then don't show enable/disable dialog.
+                if (!allNonSimAccounts.isEmpty()) {
+                    mAccountList.addPreference(mAllCallingAccounts);
+                } else {
+                    mAccountList.removePreference(mAllCallingAccounts);
+                }
             } else {
-                mAccountList.removePreference(mAllCallingAccounts);
+                getPreferenceScreen().removePreference(mAccountList);
             }
         }
     }


### PR DESCRIPTION
I see this module has moved to the archive so I suppose the AOSP one is now used directly. I skimmed through this changeset and the Dialer still has all code in place to be used with the SIP accounts. The sad thing is that for some reason Google decided to remove the builtin SIP support that was working just fine, probably because of commercial reasons and the launch of project Fi.

I'm still on a Pixel 3 so would it be possible to activate this repo and merge the PR for the Android 12 builds so the community can have the SIP accounts back? My other option is to flash my own builds but that also means compiling updates just for this feature only, which feels a bit overkil. Willing to make a donation for the effort made!

Thanks