### PR TITLE
[android-security-13.0.0_r9] Fixed leak of cross user data in multiple settings.

### DIFF
--- a/src/com/android/phone/CdmaCallForwardOptions.java
+++ b/src/com/android/phone/CdmaCallForwardOptions.java
@@ -17,10 +17,13 @@
 package com.android.phone;
 
 import android.app.ActionBar;
+import android.content.ContentProvider;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.os.PersistableBundle;
+import android.os.Process;
+import android.os.UserHandle;
 import android.preference.Preference;
 import android.preference.PreferenceScreen;
 import android.telephony.CarrierConfigManager;
@@ -212,6 +215,15 @@ public class CdmaCallForwardOptions extends TimeConsumingPreferenceActivity {
         }
         Cursor cursor = null;
         try {
+            // check if the URI returned by the user belongs to the user
+            final int currentUser = UserHandle.getUserId(Process.myUid());
+            if (currentUser
+                    != ContentProvider.getUserIdFromUri(data.getData(), currentUser)) {
+
+                Log.w(LOG_TAG, "onActivityResult: Contact data of different user, "
+                        + "cannot access");
+                return;
+            }
             cursor = getContentResolver().query(data.getData(),
                 NUM_PROJECTION, null, null, null);
             if ((cursor == null) || (!cursor.moveToFirst())) {

--- a/src/com/android/phone/GsmUmtsCallForwardOptions.java
+++ b/src/com/android/phone/GsmUmtsCallForwardOptions.java
@@ -1,10 +1,13 @@
 package com.android.phone;
 
 import android.app.ActionBar;
+import android.content.ContentProvider;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.os.PersistableBundle;
+import android.os.Process;
+import android.os.UserHandle;
 import android.preference.Preference;
 import android.preference.PreferenceScreen;
 import android.telephony.CarrierConfigManager;
@@ -203,6 +206,15 @@ public class GsmUmtsCallForwardOptions extends TimeConsumingPreferenceActivity {
         }
         Cursor cursor = null;
         try {
+            // check if the URI returned by the user belongs to the user
+            final int currentUser = UserHandle.getUserId(Process.myUid());
+            if (currentUser
+                    != ContentProvider.getUserIdFromUri(data.getData(), currentUser)) {
+
+                Log.w(LOG_TAG, "onActivityResult: Contact data of different user, "
+                        + "cannot access");
+                return;
+            }
             cursor = getContentResolver().query(data.getData(),
                 NUM_PROJECTION, null, null, null);
             if ((cursor == null) || (!cursor.moveToFirst())) {

--- a/src/com/android/phone/settings/VoicemailSettingsActivity.java
+++ b/src/com/android/phone/settings/VoicemailSettingsActivity.java
@@ -17,6 +17,7 @@
 package com.android.phone.settings;
 
 import android.app.Dialog;
+import android.content.ContentProvider;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
@@ -25,6 +26,8 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.os.PersistableBundle;
+import android.os.Process;
+import android.os.UserHandle;
 import android.os.UserManager;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
@@ -520,6 +523,17 @@ public class VoicemailSettingsActivity extends PreferenceActivity
 
             Cursor cursor = null;
             try {
+                // check if the URI returned by the user belongs to the user
+                final int currentUser = UserHandle.getUserId(Process.myUid());
+                if (currentUser
+                        != ContentProvider.getUserIdFromUri(data.getData(), currentUser)) {
+
+                    if (DBG) {
+                        log("onActivityResult: Contact data of different user, "
+                                + "cannot access");
+                    }
+                    return;
+                }
                 cursor = getContentResolver().query(data.getData(),
                     new String[] { CommonDataKinds.Phone.NUMBER }, null, null, null);
                 if ((cursor == null) || (!cursor.moveToFirst())) {

--- a/src/com/android/phone/settings/fdn/EditFdnContactScreen.java
+++ b/src/com/android/phone/settings/fdn/EditFdnContactScreen.java
@@ -19,6 +19,7 @@ package com.android.phone.settings.fdn;
 
 import static android.app.Activity.RESULT_OK;
 
+import android.content.ContentProvider;
 import android.content.ContentValues;
 import android.content.Intent;
 import android.content.res.Resources;
@@ -26,6 +27,8 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.PersistableBundle;
+import android.os.Process;
+import android.os.UserHandle;
 import android.provider.ContactsContract.CommonDataKinds;
 import android.telephony.CarrierConfigManager;
 import android.telephony.PhoneNumberUtils;
@@ -137,6 +140,14 @@ public class EditFdnContactScreen extends BaseFdnContactScreen {
                 }
                 Cursor cursor = null;
                 try {
+                    // check if the URI returned by the user belongs to the user
+                    final int currentUser = UserHandle.getUserId(Process.myUid());
+                    if (currentUser
+                            != ContentProvider.getUserIdFromUri(intent.getData(), currentUser)) {
+                        Log.w(LOG_TAG, "onActivityResult: Contact data of different user, "
+                                + "cannot access");
+                        return;
+                    }
                     cursor = getContentResolver().query(intent.getData(),
                         NUM_PROJECTION, null, null, null);
                     if ((cursor == null) || (!cursor.moveToFirst())) {


### PR DESCRIPTION
  - Any app is allowed to receive GET_CONTENT intent. Using this, an user puts back in the intent an uri with data of another user.
  - Telephony service has INTERACT_ACROSS_USER permission. Using this, it reads and shows the deta to the evil user.

Fix: When telephony service gets the intent result, it checks if the uri is from the current user or not.

Bug: b/256591023 , b/256819787

Test: The malicious behaviour was not being reproduced. Unable to import contact from other users data. Test2: Able to import contact from the primary user or uri with no user id (These settings are not available for secondary users) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:ab593467e900d4a6d25a34024a06195ae863f6dc) Merged-In: I1e3a643f17948153aecc1d0df9ffd9619ad678c1 Change-Id: I1e3a643f17948153aecc1d0df9ffd9619ad678c1